### PR TITLE
BugFix: Correctly extract top-level imports to prevent installation errors

### DIFF
--- a/streamlit_desktop_app/build.py
+++ b/streamlit_desktop_app/build.py
@@ -45,7 +45,7 @@ def extract_imports(script_path: str) -> List[str]:
     Extract a list of imported modules from a Python script.
 
     This function analyzes the AST (Abstract Syntax Tree) of a Python script
-    to identify all `import` and `from ... import ...` statements, returning 
+    to identify all `import` and `from ... import ...` statements, returning
     a list of fully qualified module names.
 
     Args:
@@ -62,16 +62,14 @@ def extract_imports(script_path: str) -> List[str]:
 
     # Traverse the AST to find import statements
     for node in ast.walk(tree):
+        # Handle `import module` or `import module as alias`
         if isinstance(node, ast.Import):
-            # Handle `import module` or `import module as alias`
             for module in node.names:
-                imports.add(module.name)  # Only add the module name
+                imports.add(module.name.split(".")[0])
+        # Handle `from module import name` or `from module import name as alias`
         elif isinstance(node, ast.ImportFrom):
-            # Handle `from module import name` or `from module import name as alias`
             if node.module:
-                for alias in node.names:
-                    # Add the fully qualified module name
-                    imports.add(f"{node.module}.{alias.name}")
+                imports.add(node.module.split(".")[0])
 
     # Return a sorted list of unique imports
     return sorted(imports)
@@ -101,10 +99,10 @@ def parse_streamlit_options(
     Examples:
         >>> parse_streamlit_options(["--theme.base", "dark"])
         {"theme.base": "dark"}
-        
+
         >>> parse_streamlit_options(["--server.headless"])
         {"server.headless": "true"}
-        
+
         >>> parse_streamlit_options({"theme.base": "dark"})
         {"theme.base": "dark"}
     """
@@ -126,7 +124,9 @@ def parse_streamlit_options(
                 options_dict[key] = value
             else:
                 current_key = token.lstrip("-")
-                options_dict[current_key] = "true"  # Assume flag is True unless overridden
+                options_dict[current_key] = (
+                    "true"  # Assume flag is True unless overridden
+                )
         else:
             # This token is the value for the last key
             if current_key:
@@ -220,7 +220,6 @@ if __name__ == "__main__":
     start_desktop_app(get_script_path(), title="{name}", options={parse_streamlit_options(streamlit_options)})
 """
         wrapper.write(wrapper_content.encode())
-
 
     args = [
         "--name",


### PR DESCRIPTION
### Description:

This pull request updates the `extract_imports` function in `streamlit_desktop_app/build.py` to only extract and utilize base module names during import detection. Previously, the function could return extended module paths (such as `requests.Session`) due to its current implementation. This behavior sometimes resulted in installation errors when the package manager incorrectly processed these extended import paths.

### Problem:

The previous implementation of `extract_imports` iterated through the Abstract Syntax Tree (AST) of the Streamlit script and directly added the full import path to the set of dependencies. This resulted in the inclusion of nested module paths (e.g., `requests.Session`) as top-level requirements. Consequently, the application might attempt to install non-existent packages or encounter errors during the dependency resolution process. As highlighted in the provided example:

```python
test_lines = """
import os
import streamlit as st
from dotenv import load_dotenv
import requests.Session as ses
from cul_cffi.requests import Session as sessi
"""

# output: ['cul_cffi.requests.Session', 'dotenv.load_dotenv', 'os', 'requests.Session', 'streamlit']
```

### Solution:

This pull request modifies the `extract_imports` function to extract only the top-level module name from both `import` and `from ... import ...` statements. This ensures that only core packages are identified as dependencies.

The provided example demonstrates the effectiveness of this fix. The new implementation correctly extracts the top-level imports:

```python
# new_output: ['cul_cffi', 'dotenv', 'os', 'requests', 'streamlit']
```

### Impact:

I believe this enhancement will contribute to a more stable and user-friendly experience with `streamlit-desktop-app` by preventing installation issues related to incorrect module path usage with accurate dependency detection and streamlined dependency management.
